### PR TITLE
FIX: JS currency formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'spree', github: 'spree/spree', branch: '3-0-stable'
-  gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-0-stable'
+  gem 'spree', github: 'spree/spree', branch: '3-1-stable'
+  gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-1-stable'
 end
 
 gemspec

--- a/app/views/spree/products/_pricing.html.erb
+++ b/app/views/spree/products/_pricing.html.erb
@@ -121,7 +121,8 @@
       var cur_customization_price = compute_customization_price();
       var cur_price = base_price + cur_variant_price_diff + cur_configuration_price + cur_customization_price;
 
-      $('.price.selling').text(cur_price.toFixed(2)).formatCurrency({region: "<%= I18n.locale.to_s %>"});
+      var region = $.formatCurrency.getRegionFromCurrency("<%= @product.currency %>");
+      $('.price.selling').text(cur_price.toFixed(2)).formatCurrency({region: region});
     }
 
     //]]>

--- a/spree_flexi_variants.gemspec
+++ b/spree_flexi_variants.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_flexi_variants'
-  s.version     = '3.0.1'
+  s.version     = '3.1.0'
   s.summary     = 'This is a spree extension that solves two use cases related to variants.'
   s.description = 'Spree extension to create product variants as-needed'
   s.required_ruby_version = '>= 2.0.0'
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '~> 3.0.0'
+  spree_version = '~> 3.1.0.beta'
 
   s.add_dependency('carrierwave')
   s.add_dependency('mini_magick')

--- a/spree_flexi_variants.gemspec
+++ b/spree_flexi_variants.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '~> 3.1.0.beta'
+  spree_version = '~> 3.1.0'
 
   s.add_dependency('carrierwave')
   s.add_dependency('mini_magick')

--- a/vendor/assets/javascripts/i18n/jquery.formatCurrency.all.js
+++ b/vendor/assets/javascripts/i18n/jquery.formatCurrency.all.js
@@ -1914,4 +1914,46 @@
 		groupDigits: true
 	};
 
+	// Create a map of currencies to regions where there would be ambiguity because
+	// the currency is shared by varying locales/regions. Canadian dolalrs, Swiss
+	// Francs, and Euros are prime examples.
+	$.formatCurrency.currencyRegionMap = {
+		'CAD': 'en-CA',
+		'CHF': 'de-CH',
+		'EUR': 'de-DE',
+		'GBP': 'en-GB',
+		'HKD': 'en-HK',
+		'NOK': 'nb-NO',
+		'SEK': 'sv-SE',
+		'SGD': 'en-SG',
+		'USD': 'en'
+	};
+
+	$.formatCurrency.getRegionFromCurrency = function(currency) {
+		currency = currency.toUpperCase();
+
+		// First, see if there's an explicit mapping of a currency to a region/locale
+		var region = $.formatCurrency.currencyRegionMap[currency];
+		if (region) {
+			return region;
+		}
+
+		// Next, try to find a region based on the code shared by the currency and region.
+		// For example DK is the country code for Denmark and found in DKK and da-DK
+		// Note that we're using shift() to pick the first region detected. In cases
+		// where there are multiple matches this may not be desirable. Add an explicit
+		// mapping to the currencyRegionMap in such cases. Ex) cy-GB would come before en-GB
+		var countryCode = currency.substring(0, 2);
+		region = $.grep(Object.keys($.formatCurrency.regions), function(code) {
+			return code.split('-')[1] == countryCode;
+		}).shift();
+
+		if (region) {
+			return region;
+		}
+
+		// Finally, give up and use English...
+		return 'en';
+	};
+
 })(jQuery);


### PR DESCRIPTION
Currency formatting was hardcoded to use English. This is great for dollars but wrong for every other currency. For example if your web shop was using Euros and you had `use_javascript_pricing_updates` switched on, the price would be formatted in dollars.

Now you can explicitly map currencies to locales Ex) EUR => de-DE, or a best guess is made by matching ISO country codes on currencies and regions. Ex) AUD => en-AU, DKK => da-DK.
