### PR TITLE
Change $(document).ready to Spree.ready

### DIFF
--- a/app/assets/javascripts/spree/frontend/spree_flexi_variants.js
+++ b/app/assets/javascripts/spree/frontend/spree_flexi_variants.js
@@ -2,7 +2,7 @@
 //= require i18n/jquery.formatCurrency.all
 //= require_self
 
-$(function () {
+Spree.ready(function () {
   // set up the 'reset' functionality on file uploads
   $("#cart-form form input[type=file]").each(function () {
   // make a clone of the original in case the user wants to undo an upload

--- a/app/assets/javascripts/spree/frontend/spree_flexi_variants_exclusions.js
+++ b/app/assets/javascripts/spree/frontend/spree_flexi_variants_exclusions.js
@@ -186,7 +186,7 @@ function possibleCombinations (options) {
 }
 
 
-$(document).ready(function() {
+Spree.ready(function() {
   // initialize all the 'options'
   $('select.ad_hoc').each(function() {
     var options = [];

--- a/app/overrides/add_content_for_body_javascript_to_show_product.rb
+++ b/app/overrides/add_content_for_body_javascript_to_show_product.rb
@@ -2,5 +2,5 @@ Deface::Override.new(
   virtual_path: "spree/products/show",
   name: "converted_cart_form_594755007",
   insert_before: "[data-hook='cart_form'], #cart-form[data-hook]",
-  partial: "spree/products/content_for_head"
+  partial: "spree/products/content_for_body_javascript"
 )

--- a/app/overrides/add_flexi_variants_javascript_body_yield.rb
+++ b/app/overrides/add_flexi_variants_javascript_body_yield.rb
@@ -1,0 +1,6 @@
+Deface::Override.new(
+  virtual_path: "spree/layouts/spree_application",
+  name: "add_flexi_variants_javascript_body_yield",
+  insert_bottom: "body",
+  partial: "spree/shared/flexi_variants_body_js"
+)

--- a/app/views/spree/admin/product_customization_types/edit.html.erb
+++ b/app/views/spree/admin/product_customization_types/edit.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :head do %>
   <%= javascript_tag do %>
-    $(function () {
+    Spree.ready(function () {
       $('form').validate();
     });
   <% end %>

--- a/app/views/spree/products/_content_for_body_javascript.html.erb
+++ b/app/views/spree/products/_content_for_body_javascript.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :head do %>
+<%= content_for :flexi_variants_body_js do %>
   <% if @product.ad_hoc_variant_exclusions.present? %>
     <%= javascript_tag do %>
       var exclusions = [

--- a/app/views/spree/products/_pricing.html.erb
+++ b/app/views/spree/products/_pricing.html.erb
@@ -1,5 +1,5 @@
 <% if SpreeFlexiVariants::Config[:use_javascript_pricing_updates] %>
-  <%= content_for :head do %>
+  <%= content_for :flexi_variants_body_js do %>
     <%# didn't use javascript_tag here so we don't confuse deface %>
     <script type="text/javascript">
       //<![CDATA[
@@ -37,7 +37,7 @@
         };
       })();
 
-      $(function() {
+      Spree.ready(function() {
 
         // watch for variant changes
         $("#product-variants input[type='radio']").change(function() {
@@ -52,7 +52,9 @@
           updatePrice();
         });
 
-        updatePrice(); // set the initial price
+        if ($('.ad-hoc-option-select').length) {
+          updatePrice(); // set the initial price
+        }
       }); // ready
 
     // stolen from http://stackoverflow.com/questions/18082/validate-numbers-in-javascript-isnumeric
@@ -113,7 +115,6 @@
 
       return price;
     }
-
 
     function updatePrice() {
       var cur_variant_price_diff = compute_variant_price_diff(base_price);

--- a/app/views/spree/products/customizations/calculator/_amount_times_constant.html.erb
+++ b/app/views/spree/products/customizations/calculator/_amount_times_constant.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :head do %>
+<%= content_for :flexi_variants_body_js do %>
 
   <%= javascript_tag do %>
     function calculate_amount_times_constant_price(obj) {

--- a/app/views/spree/products/customizations/calculator/_customization_image.html.erb
+++ b/app/views/spree/products/customizations/calculator/_customization_image.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :head do %>
+<%= content_for :flexi_variants_body_js do %>
 
   <%= javascript_tag do %>
   function calculate_customization_image_price(obj) {

--- a/app/views/spree/products/customizations/calculator/_engraving.html.erb
+++ b/app/views/spree/products/customizations/calculator/_engraving.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :head do %>
+<%= content_for :flexi_variants_body_js do %>
 
   <%= javascript_tag do %>
     function calculate_engraving_price(obj) {

--- a/app/views/spree/products/customizations/calculator/_product_area.html.erb
+++ b/app/views/spree/products/customizations/calculator/_product_area.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :head do %>
+<%= content_for :flexi_variants_body_js do %>
 
   <%= javascript_tag do %>
     function calculate_product_area_price(obj) {

--- a/app/views/spree/products/customizations/calculator_type/_amount_times_constant.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_amount_times_constant.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: "spree/products/customizations/calculator/#{calculator_name(product_customization_type)}", locals: {calculator: product_customization_type.calculator} %>
 <%# add the 'change' listener for this particular file input, which will make use of the calculator above %>
 
-<%= content_for :head do %>
+<%= content_for :flexi_variants_body_js do %>
   <%= javascript_tag do %>
     $(document).on('keyup', '#<%= cust_dom_id %>', function(e) {
 

--- a/app/views/spree/products/customizations/calculator_type/_customization_image.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_customization_image.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: "spree/products/customizations/calculator/#{calculator_name(product_customization_type)}", locals: {calculator: product_customization_type.calculator} %>
 <%# add the 'change' listener for this particular file input, which will make use of the calculator above %>
 
-<%= content_for :head do %>
+<%= content_for :flexi_variants_body_js do %>
   <%= javascript_tag do %>
     $(document).on('change', '#<%= cust_dom_id %>', function(e) {
 
@@ -43,4 +43,3 @@ $("#myform").validate({
   }
 });
 -->
-

--- a/app/views/spree/products/customizations/calculator_type/_engraving.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_engraving.html.erb
@@ -7,7 +7,7 @@
 
   <%# add the 'change' listener for this particular file input, which will make use of the calculator above %>
 
-  <%= content_for :head do %>
+  <%= content_for :flexi_variants_body_js do %>
     <%= javascript_tag do %>
       $(document).on('keyup', '#<%= cust_dom_id %>', function(e) {
 
@@ -34,4 +34,3 @@
     <%= hidden_field_tag "customization_price", "0", class: "customization_price" %>
   </div>
 </div>
-

--- a/app/views/spree/products/customizations/calculator_type/_product_area.html.erb
+++ b/app/views/spree/products/customizations/calculator_type/_product_area.html.erb
@@ -4,7 +4,7 @@
 <%= render partial: "spree/products/customizations/calculator/#{calculator_name(product_customization_type)}", locals: {calculator: product_customization_type.calculator} %>
 <% # add the 'change' listener for this particular file input, which will make use of the calculator above %>
 
-<%= content_for :head do %>
+<%= content_for :flexi_variants_body_js do %>
   <%= javascript_tag do %>
     function product_area_keyup() {
       var text_field = $(this);
@@ -34,4 +34,3 @@
   <%# the price is stored here on change, and later collected by the product-wide updatePrice() %>
   <%= hidden_field_tag "customization_price", "0", class: "customization_price" %>
 </div>
-

--- a/app/views/spree/shared/_flexi_variants_body_js.html.erb
+++ b/app/views/spree/shared/_flexi_variants_body_js.html.erb
@@ -1,0 +1,1 @@
+<%= yield :flexi_variants_body_js %>


### PR DESCRIPTION
Change $(document).ready to Spree.ready - to save compatibility with turbolinks

Change content_for_head (javascript operations) to content_for_body_javascript - turbolinks inject only head title and body.
"add_flexi_variants_javascript_body_yield" is override for store javascript into body becouse turbolinks inject only body without head content
