### PR TITLE
Fixed "Unable to add to cart" issue added by spree 3.3

### DIFF
--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -10,7 +10,11 @@ module Spree
         line_item.quantity += quantity.to_i
         line_item.currency = currency unless currency.nil?
       else
-        opts = { currency: order.currency }.merge ActionController::Parameters.new(options).permit(PermittedAttributes.line_item_attributes)
+        options_params = options.is_a?(ActionController::Parameters) ? options : ActionController::Parameters.new(options.to_h)
+        opts = options_params.
+          permit(PermittedAttributes.line_item_attributes).to_h.
+          merge(currency: order.currency)
+
         line_item = order.line_items.new(quantity: quantity, variant: variant, options: opts)
 
         product_customizations_values = options[:product_customizations] || []

--- a/spree_flexi_variants.gemspec
+++ b/spree_flexi_variants.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_flexi_variants'
-  s.version     = '3.2.0'
+  s.version     = '3.3.0'
   s.summary     = 'This is a spree extension that solves two use cases related to variants.'
   s.description = 'Spree extension to create product variants as-needed'
   s.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
As described by issue #13 and #15, spree 3.3 breaks "add to cart" action by changing the way product options are passed down to models. This is a fix based on the current version of spree's order_contents model.